### PR TITLE
feat(token-wallet): Phase 1 — double-entry ledger engine with credit endpoint

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -7,7 +7,8 @@
 | **Wallet** | A user's or organization's token balance container with posted, pending, and available amounts | Account, purse, balance |
 | **Wallet Account** | A ledger account that tracks posted/pending/available balances and is one of four account types | Ledger account, balance account |
 | **Account Type** | The classification of a Wallet Account: USER_WALLET, SYSTEM_REVENUE, SYSTEM_ESCROW, or SYSTEM_RESERVE | Account kind, account category |
-| **Reference** | The entity that owns a Wallet — either a user or an organization, identified by referenceId + referenceType | Owner, holder, customer |
+| **Reference** | The entity that owns a Wallet — either a user or an organization, identified by a Reference Key | Owner, holder, customer |
+| **Reference Key** | A single unique string identifying a Reference, formed as `"user:{userId}"` or `"org:{orgId}"` | referenceId, composite key |
 | **Posted Balance** | The settled, confirmed token amount in a Wallet Account | Confirmed balance, settled balance, actual balance |
 | **Pending Debits** | The total tokens currently locked by active Holds in a Wallet Account | Held amount, reserved tokens |
 | **Available Balance** | The tokens free to spend, computed as Posted Balance minus Pending Debits | Free balance, spendable balance |
@@ -47,6 +48,7 @@
 | **SYSTEM_REVENUE** | A Wallet Account that receives tokens when users consume them (the "other side" of a Debit) | Revenue account, income account |
 | **SYSTEM_ESCROW** | A Wallet Account that temporarily holds tokens reserved by active Holds | Escrow account, hold account |
 | **SYSTEM_RESERVE** | A Wallet Account used for refunds and manual adjustments | Reserve account, adjustment account |
+| **System Account Seeding** | The act of creating the three system singleton accounts (REVENUE, ESCROW, RESERVE) on plugin initialization | System init, account setup |
 
 ## Preflight Modes
 
@@ -70,6 +72,14 @@
 | **Optimistic Locking** | A concurrency strategy where writes check the Lock Version and retry if it changed | OCC, version checking |
 | **Pessimistic Locking** | A concurrency strategy where database rows are locked with SELECT FOR UPDATE during reads | Row locking, DB lock |
 
+## Error Handling
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Error Code** | A specific string identifier for a failure condition in a wallet operation (e.g., WALLET_NOT_FOUND, INVALID_AMOUNT) | Error type, failure code |
+
+Phase 1 error codes: WALLET_NOT_FOUND, INVALID_AMOUNT, DUPLICATE_IDEMPOTENCY_KEY, SYSTEM_ACCOUNT_MISSING, MISSING_IDEMPOTENCY_KEY, CREDIT_FAILED
+
 ## Relationships
 
 - A **Reference** (user or organization) has exactly one **USER_WALLET** Wallet Account
@@ -84,6 +94,9 @@
 - A **Capture** Voids the Hold and creates a new Transaction that Debits **USER_WALLET** (posted) and Credits **SYSTEM_REVENUE** (posted)
 - An **Available Balance** is always Posted Balance minus Pending Debits
 - A **Wallet** balance can never go below zero (strict prepaid)
+- A **Reference Key** uniquely identifies a **Reference** (format: `"user:{id}"` or `"org:{id}"`)
+- **System Account Seeding** creates three system Wallet Accounts on plugin initialization
+- A **CREDIT_TOPUP** Transaction always involves two entries: DEBIT **SYSTEM_REVENUE** and CREDIT **USER_WALLET**
 
 ## Example dialogue
 
@@ -103,6 +116,20 @@
 >
 > **Domain expert:** "The first **Preflight** succeeds — it reserves 500. The second sees **Available Balance** is now 100, which is insufficient, so it's rejected. If both somehow reach the write simultaneously, **Optimistic Locking** via the **Lock Version** prevents the second write — it retries with the updated balance."
 
+## Example dialogue (Phase 1: Credit Flow)
+
+> **Dev:** "When a **User** signs up, how does their **Wallet** get created?"
+>
+> **Domain expert:** "The plugin registers a **database hook** on user creation. When the **User** is created, a **USER_WALLET** **Wallet Account** is auto-created with the configured **Initial Balance**. If that hook fails for any reason, the **Credit Endpoint** uses a **find-or-create** pattern to self-heal — it creates the missing wallet on the first **Top-Up**."
+>
+> **Dev:** "What if I **Top-Up** 1000 **Tokens** for a **User** — how does the **Double-Entry** work?"
+>
+> **Domain expert:** "The **Credit Endpoint** creates a **CREDIT_TOPUP** **Transaction** with two **Entries**: DEBIT 1000 from **SYSTEM_REVENUE** and CREDIT 1000 to the **USER_WALLET**. Both the **Posted Balance** and **Available Balance** increase by 1000. The **Double-Entry** invariant holds: SUM(debits) = SUM(credits) = 1000."
+>
+> **Dev:** "What if the payment webhook fires twice?"
+>
+> **Domain expert:** "Every **Top-Up** requires an **Idempotency Key**. The second request with the same key finds the existing **Transaction** and returns the original result — no second **Credit**, no balance change."
+
 ## Flagged ambiguities
 
 - **"Account"** was used ambiguously throughout the design conversation — sometimes meaning a Better Auth user account, sometimes a Wallet Account, and sometimes the account types (USER_WALLET, SYSTEM_REVENUE, etc.). **Canonical usage:** "Wallet Account" for the ledger entity, "User" or "Organization" for the Better Auth entity. Never use "account" alone.
@@ -111,3 +138,6 @@
 - **"Balance"** alone is ambiguous — it could mean posted, pending, or available. **Canonical usage:** Always qualify as "Posted Balance", "Pending Debits", or "Available Balance". Never say just "balance".
 - **"Capture" vs "Settle" vs "Postflight"** — Capture is the specific act of resolving a Hold with actual cost. Postflight is the endpoint that triggers Capture. Settle is too vague. **Canonical:** "Capture" for the ledger operation, "Postflight" for the API endpoint.
 - **"Preflight"** is used as both an endpoint name and a concept. The endpoint `/token-wallet/preflight` can operate in Hold Mode or Check Mode — these are distinct strategies, not synonyms for Preflight itself.
+- **"referenceId + referenceType"** was used in the original PRD to identify a Reference as two separate fields. **Canonical usage**: A single **Reference Key** string (e.g., `"user:abc123"`) replaces the two-field approach. The original fields are merged for simplicity and to enable single-field unique constraints.
+- **"Initial Balance"** could mean either the starting column value or a real CREDIT_TOPUP transaction. **Canonical usage**: When `initialBalance > 0`, a real **CREDIT_TOPUP** **Transaction** is created (ledger integrity), not just a column set.
+

--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
     "typescript": "catalog:",
     "@changesets/cli": "^2.29.0",
     "vitest": "^3.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/packages/token-wallet/package.json
+++ b/packages/token-wallet/package.json
@@ -43,7 +43,12 @@
   "peerDependencies": {
     "better-auth": "catalog:"
   },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
   "devDependencies": {
+    "better-auth": "catalog:",
+    "better-sqlite3": "^12.0.0",
     "typescript": "catalog:",
     "vite-plus": "^0.1.14"
   },

--- a/packages/token-wallet/src/__tests__/balance.test.ts
+++ b/packages/token-wallet/src/__tests__/balance.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestAdapter } from "./helpers/test-setup.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import { creditBalance, getBalance, validateAmount } from "../balance/index.js";
+import { seedSystemAccounts } from "../system-accounts/index.js";
+import { getOrCreateUserWallet } from "../wallet-account/index.js";
+
+describe("balance module", () => {
+  let adapter: WalletAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  describe("validateAmount", () => {
+    it("accepts positive integers", () => {
+      expect(() => validateAmount(1)).not.toThrow();
+      expect(() => validateAmount(100)).not.toThrow();
+    });
+
+    it("rejects zero", () => {
+      expect(() => validateAmount(0)).toThrow("INVALID_AMOUNT");
+    });
+
+    it("rejects negative numbers", () => {
+      expect(() => validateAmount(-5)).toThrow("INVALID_AMOUNT");
+    });
+
+    it("rejects decimals", () => {
+      expect(() => validateAmount(1.5)).toThrow("INVALID_AMOUNT");
+    });
+  });
+
+  describe("creditBalance", () => {
+    it("credits posted and available balance", async () => {
+      await seedSystemAccounts(adapter);
+      await creditBalance(adapter, "sys_revenue", 500);
+
+      const account = await adapter.findOne({
+        model: "walletAccount",
+        where: [{ field: "id", value: "sys_revenue" }],
+      });
+      expect(account?.postedBalance).toBe(500);
+      expect(account?.availableBalance).toBe(500);
+    });
+
+    it("throws WALLET_NOT_FOUND for missing account", async () => {
+      await expect(
+        creditBalance(adapter, "nonexistent", 100),
+      ).rejects.toThrow("WALLET_NOT_FOUND");
+    });
+
+    it("accumulates multiple credits", async () => {
+      await seedSystemAccounts(adapter);
+      await creditBalance(adapter, "sys_revenue", 100);
+      await creditBalance(adapter, "sys_revenue", 200);
+
+      const account = await adapter.findOne({
+        model: "walletAccount",
+        where: [{ field: "id", value: "sys_revenue" }],
+      });
+      expect(account?.postedBalance).toBe(300);
+    });
+  });
+
+  describe("getBalance", () => {
+    it("returns balance for existing wallet", async () => {
+      await getOrCreateUserWallet(adapter, "user:alice", 250);
+      const balance = await getBalance(adapter, "user:alice");
+
+      expect(balance).toEqual({
+        posted: 250,
+        pending: 0,
+        available: 250,
+      });
+    });
+
+    it("throws WALLET_NOT_FOUND for missing wallet", async () => {
+      await expect(getBalance(adapter, "user:ghost")).rejects.toThrow(
+        "WALLET_NOT_FOUND",
+      );
+    });
+  });
+});

--- a/packages/token-wallet/src/__tests__/client-plugin.test.ts
+++ b/packages/token-wallet/src/__tests__/client-plugin.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { tokenWalletClient } from "../client.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+import { tokenWallet } from "../index.js";
+
+describe("client plugin", () => {
+  it("returns object with $InferServerPlugin", () => {
+    const client = tokenWalletClient();
+    expect(client.$InferServerPlugin).toBeDefined();
+  });
+
+  it("has pathMethods mapping credit to POST", () => {
+    const client = tokenWalletClient();
+    expect(client.pathMethods).toBeDefined();
+    expect(client.pathMethods!["/token-wallet/credit"]).toBe("POST");
+  });
+
+  it("has $ERROR_CODES matching server error codes", () => {
+    const client = tokenWalletClient();
+    expect(client.$ERROR_CODES).toEqual(TOKEN_WALLET_ERROR_CODES);
+    const codes = Object.keys(client.$ERROR_CODES!);
+    expect(codes).toContain("WALLET_NOT_FOUND");
+    expect(codes).toContain("INVALID_AMOUNT");
+    expect(codes).toContain("DUPLICATE_IDEMPOTENCY_KEY");
+    expect(codes).toContain("SYSTEM_ACCOUNT_MISSING");
+    expect(codes).toContain("MISSING_IDEMPOTENCY_KEY");
+    expect(codes).toContain("CREDIT_FAILED");
+  });
+
+  it("client $InferServerPlugin has expected type shape", () => {
+    const client = tokenWalletClient();
+    expect(client.$InferServerPlugin).toBeDefined();
+    expect(typeof client.$InferServerPlugin).toBe("object");
+  });
+
+  it("all exported types are importable", () => {
+    expect(typeof tokenWallet).toBe("function");
+    expect(typeof tokenWalletClient).toBe("function");
+    expect(typeof TOKEN_WALLET_ERROR_CODES).toBe("object");
+  });
+});

--- a/packages/token-wallet/src/__tests__/credit-endpoint.test.ts
+++ b/packages/token-wallet/src/__tests__/credit-endpoint.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTestAuth } from "./helpers/test-auth.js";
+import { SYSTEM_ACCOUNT_IDS } from "../system-accounts/index.js";
+import type { TokenWalletOptions } from "../types.js";
+
+async function signUpDirect(
+  auth: ReturnType<typeof createTestAuth>["auth"],
+): Promise<{ userId: string; cookies: string }> {
+  const req = new Request("http://localhost:3000/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: `credit-${Date.now()}@example.com`,
+      password: "test1234",
+      name: "Test User",
+    }),
+  });
+  const res = await auth.handler(req);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Sign up failed: ${res.status} ${body}`);
+  }
+  const data = (await res.json()) as Record<string, Record<string, unknown>>;
+  const setCookieHeaders = res.headers.getSetCookie();
+  const cookies = setCookieHeaders.map((c) => c.split(";")[0]).join("; ");
+  return {
+    userId: data.user?.id as string,
+    cookies,
+  };
+}
+
+async function callCredit(
+  auth: ReturnType<typeof createTestAuth>["auth"],
+  cookies: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const req = new Request(
+    "http://localhost:3000/api/auth/token-wallet/credit",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookies,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  return auth.handler(req);
+}
+
+describe("credit endpoint", () => {
+  it("creates CREDIT_TOPUP transaction with balanced entries", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "credit-test-1",
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.transaction).toBeDefined();
+    expect(data.transaction.transactionType).toBe("CREDIT_TOPUP");
+    expect(data.transaction.idempotencyKey).toBe("credit-test-1");
+    expect(data.transaction.status).toBe("posted");
+
+    expect(data.entries).toHaveLength(2);
+    const debitEntry = data.entries.find(
+      (e: Record<string, unknown>) => e.entryType === "DEBIT",
+    );
+    const creditEntry = data.entries.find(
+      (e: Record<string, unknown>) => e.entryType === "CREDIT",
+    );
+    expect(debitEntry).toBeDefined();
+    expect(creditEntry).toBeDefined();
+    expect(debitEntry.accountId).toBe(SYSTEM_ACCOUNT_IDS.REVENUE);
+    expect(debitEntry.amount).toBe(100);
+    expect(creditEntry.amount).toBe(100);
+  });
+
+  it("increases posted and available balance by credited amount", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 250,
+      idempotencyKey: "balance-test-1",
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.balance).toBeDefined();
+    expect(data.balance.posted).toBe(250);
+    expect(data.balance.available).toBe(250);
+  });
+
+  it("returns original result on duplicate idempotency key", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const first = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "dup-key-1",
+    });
+    expect(first.status).toBe(200);
+    const data1 = await first.json();
+
+    const second = await callCredit(auth, cookies, {
+      amount: 50,
+      idempotencyKey: "dup-key-1",
+    });
+    expect(second.status).toBe(200);
+    const data2 = await second.json();
+
+    expect(data2.transaction.idempotencyKey).toBe("dup-key-1");
+    expect(data2.balance.posted).toBe(100);
+  });
+
+  it("rejects missing idempotency key", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 100,
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid amount (zero)", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 0,
+      idempotencyKey: "zero-amount",
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid amount (negative)", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: -50,
+      idempotencyKey: "neg-amount",
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("fires onTopUp hook with correct context", async () => {
+    const onTopUp = vi.fn();
+    const { auth } = createTestAuth({
+      hooks: { onTopUp },
+    } satisfies TokenWalletOptions);
+    const { cookies, userId } = await signUpDirect(auth);
+
+    await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "hook-test-1",
+    });
+
+    expect(onTopUp).toHaveBeenCalledOnce();
+    const hookCtx = onTopUp.mock.calls[0]![0];
+    expect(hookCtx.transaction.transactionType).toBe("CREDIT_TOPUP");
+    expect(hookCtx.entries).toHaveLength(2);
+    expect(hookCtx.user.id).toBe(userId);
+    expect(hookCtx.wallet).toBeDefined();
+  });
+
+  it("accumulates multiple credits correctly", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "accum-1",
+    });
+    const res2 = await callCredit(auth, cookies, {
+      amount: 150,
+      idempotencyKey: "accum-2",
+    });
+
+    expect(res2.status).toBe(200);
+    const data2 = await res2.json();
+    expect(data2.balance.posted).toBe(250);
+    expect(data2.balance.available).toBe(250);
+  });
+
+  it("creates wallet for user without existing wallet", async () => {
+    const { auth } = createTestAuth({
+      wallet: { autoCreate: false },
+    } satisfies TokenWalletOptions);
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "no-wallet-1",
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.balance.posted).toBe(100);
+  });
+});

--- a/packages/token-wallet/src/__tests__/foundation.test.ts
+++ b/packages/token-wallet/src/__tests__/foundation.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { tokenWallet } from "../index.js";
+import { tokenWalletClient } from "../client.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+
+describe("tokenWallet plugin shape", () => {
+  it("has id 'token-wallet'", () => {
+    const plugin = tokenWallet();
+    expect(plugin.id).toBe("token-wallet");
+  });
+
+  it("has schema with 4 tables", () => {
+    const plugin = tokenWallet();
+    expect(plugin.schema).toBeDefined();
+    const tables = Object.keys(plugin.schema!);
+    expect(tables).toHaveLength(4);
+    expect(tables).toContain("walletAccount");
+    expect(tables).toContain("walletTransaction");
+    expect(tables).toContain("walletEntry");
+    expect(tables).toContain("walletHold");
+  });
+
+  it("has init function", () => {
+    const plugin = tokenWallet();
+    expect(typeof plugin.init).toBe("function");
+  });
+
+  it("init returns object with options.databaseHooks", () => {
+    const plugin = tokenWallet();
+    expect(plugin.init).toBeDefined();
+    expect(typeof plugin.init).toBe("function");
+
+    if (!plugin.init) return;
+    const initResult = plugin.init({} as Parameters<typeof plugin.init>[0]);
+
+    type InitReturn = Awaited<ReturnType<typeof plugin.init>> & {
+      options: {
+        databaseHooks: {
+          user: { create: { after: (...args: unknown[]) => Promise<unknown> } };
+        };
+      };
+    };
+    const result = initResult as InitReturn;
+    expect(result.options).toBeDefined();
+    expect(result.options.databaseHooks).toBeDefined();
+    expect(result.options.databaseHooks.user).toBeDefined();
+    expect(result.options.databaseHooks.user.create).toBeDefined();
+    expect(typeof result.options.databaseHooks.user.create.after).toBe(
+      "function",
+    );
+  });
+
+  it("has $Infer with options", () => {
+    const plugin = tokenWallet();
+    expect(plugin.$Infer).toBeDefined();
+    expect(plugin.$Infer!.options).toBeUndefined();
+  });
+
+  it("has $Infer with options when options provided", () => {
+    const opts = { wallet: { autoCreate: true, initialBalance: 100 } };
+    const plugin = tokenWallet(opts);
+    expect(plugin.$Infer!.options).toEqual(opts);
+  });
+
+  it("has $ERROR_CODES with 6 codes", () => {
+    const plugin = tokenWallet();
+    expect(plugin.$ERROR_CODES).toBeDefined();
+    const codes = Object.keys(plugin.$ERROR_CODES!);
+    expect(codes).toHaveLength(6);
+    expect(codes).toContain("WALLET_NOT_FOUND");
+    expect(codes).toContain("INVALID_AMOUNT");
+    expect(codes).toContain("DUPLICATE_IDEMPOTENCY_KEY");
+    expect(codes).toContain("SYSTEM_ACCOUNT_MISSING");
+    expect(codes).toContain("MISSING_IDEMPOTENCY_KEY");
+    expect(codes).toContain("CREDIT_FAILED");
+  });
+
+  it("endpoints has credit endpoint", () => {
+    const plugin = tokenWallet();
+    expect(plugin.endpoints).toBeDefined();
+    expect(plugin.endpoints!.credit).toBeDefined();
+  });
+});
+
+describe("tokenWalletClient plugin shape", () => {
+  it("has id 'token-wallet'", () => {
+    const client = tokenWalletClient();
+    expect(client.id).toBe("token-wallet");
+  });
+
+  it("has $InferServerPlugin", () => {
+    const client = tokenWalletClient();
+    expect(client.$InferServerPlugin).toBeDefined();
+  });
+
+  it("has pathMethods with /token-wallet/credit as POST", () => {
+    const client = tokenWalletClient();
+    expect(client.pathMethods).toBeDefined();
+    expect(client.pathMethods!["/token-wallet/credit"]).toBe("POST");
+  });
+
+  it("has $ERROR_CODES matching server plugin", () => {
+    const client = tokenWalletClient();
+    expect(client.$ERROR_CODES).toEqual(TOKEN_WALLET_ERROR_CODES);
+  });
+});

--- a/packages/token-wallet/src/__tests__/helpers/test-auth.ts
+++ b/packages/token-wallet/src/__tests__/helpers/test-auth.ts
@@ -1,0 +1,67 @@
+import { betterAuth } from "better-auth";
+import type { Auth, BetterAuthOptions } from "better-auth";
+import { createAuthClient } from "better-auth/client";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { tokenWallet } from "../../index.js";
+import type { TokenWalletOptions } from "../../types.js";
+
+export function createTestAuth(pluginOptions?: TokenWalletOptions): {
+  auth: Auth<BetterAuthOptions>;
+  client: ReturnType<typeof createAuthClient>;
+} {
+  const auth = betterAuth({
+    emailAndPassword: { enabled: true },
+    database: memoryAdapter({
+      user: [],
+      session: [],
+      account: [],
+      verification: [],
+      walletAccount: [],
+      walletTransaction: [],
+      walletEntry: [],
+      walletHold: [],
+    }),
+    plugins: [tokenWallet(pluginOptions)],
+  });
+
+  const client = createAuthClient({
+    baseURL: "http://localhost:3000",
+    fetchOptions: {
+      customFetchImpl: async (
+        url: string | URL | Request,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        const req = new Request(url.toString(), init);
+        return auth.handler(req) as Promise<Response>;
+      },
+    },
+  });
+
+  return { auth: auth, client: client };
+}
+
+export async function createTestUser(
+  client: ReturnType<typeof createTestAuth>["client"],
+  email?: string,
+): Promise<{
+  user: { id: string; email: string; name: string };
+  token: string | null;
+}> {
+  const testEmail = email ?? `test-${Date.now()}@example.com`;
+  const res = await client.signUp.email({
+    email: testEmail,
+    password: "test1234",
+    name: "Test User",
+  });
+
+  if (res.error) {
+    throw new Error(
+      `Failed to create test user: ${JSON.stringify(res.error)}`,
+    );
+  }
+
+  return {
+    user: res.data!.user,
+    token: res.data!.token,
+  };
+}

--- a/packages/token-wallet/src/__tests__/helpers/test-setup.ts
+++ b/packages/token-wallet/src/__tests__/helpers/test-setup.ts
@@ -1,0 +1,23 @@
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { tokenWallet } from "../../index.js";
+import type { WalletAdapter } from "../../ledger/index.js";
+
+export function createTestAdapter(): WalletAdapter {
+  const auth = betterAuth({
+    emailAndPassword: { enabled: true },
+    database: memoryAdapter({
+      user: [],
+      session: [],
+      account: [],
+      verification: [],
+      walletAccount: [],
+      walletTransaction: [],
+      walletEntry: [],
+      walletHold: [],
+    }),
+    plugins: [tokenWallet()],
+  });
+  const factory = auth.options.database;
+  return factory(auth.options) as WalletAdapter;
+}

--- a/packages/token-wallet/src/__tests__/idempotency.test.ts
+++ b/packages/token-wallet/src/__tests__/idempotency.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestAdapter } from "./helpers/test-setup.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import { checkOrStore } from "../idempotency/index.js";
+
+describe("idempotency module", () => {
+  let adapter: WalletAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  it("runs operation when key is new", async () => {
+    const result = await checkOrStore(adapter, "key-001", async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("stores a transaction record on success", async () => {
+    await checkOrStore(adapter, "key-002", async () => "done");
+
+    const tx = await adapter.findOne({
+      model: "walletTransaction",
+      where: [{ field: "idempotencyKey", value: "key-002" }],
+    });
+    expect(tx).toBeNull();
+  });
+
+  it("throws MISSING_IDEMPOTENCY_KEY for empty key", async () => {
+    await expect(checkOrStore(adapter, "", async () => 1)).rejects.toThrow(
+      "MISSING_IDEMPOTENCY_KEY",
+    );
+  });
+
+  it("throws MISSING_IDEMPOTENCY_KEY for whitespace key", async () => {
+    await expect(checkOrStore(adapter, "   ", async () => 1)).rejects.toThrow(
+      "MISSING_IDEMPOTENCY_KEY",
+    );
+  });
+
+  it("returns existing result on duplicate key", async () => {
+    await adapter.create({
+      model: "walletTransaction",
+      data: {
+        id: "tx-dup-1",
+        idempotencyKey: "dup-key",
+        transactionType: "CREDIT_TOPUP",
+        status: "posted",
+      },
+    });
+
+    const callCount = { value: 0 };
+    const result = await checkOrStore(adapter, "dup-key", async () => {
+      callCount.value++;
+      return { data: "nope" };
+    });
+
+    expect(callCount.value).toBe(0);
+    expect(result).toHaveProperty("transaction");
+    expect(result).toHaveProperty("entries");
+  });
+});

--- a/packages/token-wallet/src/__tests__/integration.test.ts
+++ b/packages/token-wallet/src/__tests__/integration.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTestAuth } from "./helpers/test-auth.js";
+import { SYSTEM_ACCOUNT_IDS } from "../system-accounts/index.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import type { TokenWalletOptions } from "../types.js";
+
+async function signUpDirect(
+  auth: ReturnType<typeof createTestAuth>["auth"],
+): Promise<{ userId: string; cookies: string }> {
+  const req = new Request("http://localhost:3000/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: `intg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`,
+      password: "test1234",
+      name: "Test User",
+    }),
+  });
+  const res = await auth.handler(req);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Sign up failed: ${res.status} ${body}`);
+  }
+  const data = (await res.json()) as Record<string, Record<string, unknown>>;
+  const setCookieHeaders = res.headers.getSetCookie();
+  const cookies = setCookieHeaders.map((c) => c.split(";")[0]).join("; ");
+  return {
+    userId: data.user?.id as string,
+    cookies,
+  };
+}
+
+async function callCredit(
+  auth: ReturnType<typeof createTestAuth>["auth"],
+  cookies: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const req = new Request(
+    "http://localhost:3000/api/auth/token-wallet/credit",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookies,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  return auth.handler(req);
+}
+
+function getAdapter(
+  auth: ReturnType<typeof createTestAuth>["auth"],
+): WalletAdapter {
+  const factory = auth.options.database;
+  return factory(auth.options) as unknown as WalletAdapter;
+}
+
+describe("integration: full credit lifecycle", () => {
+  it("happy path: create user → credit → verify balance → duplicate returns 200", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res1 = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "lifecycle-1",
+    });
+    expect(res1.status).toBe(200);
+    const data1 = await res1.json();
+    expect(data1.balance).toEqual({ posted: 100, available: 100, pending: 0 });
+
+    const res2 = await callCredit(auth, cookies, {
+      amount: 200,
+      idempotencyKey: "lifecycle-2",
+    });
+    expect(res2.status).toBe(200);
+    const data2 = await res2.json();
+    expect(data2.balance).toEqual({ posted: 300, available: 300, pending: 0 });
+
+    const res3 = await callCredit(auth, cookies, {
+      amount: 999,
+      idempotencyKey: "lifecycle-1",
+    });
+    expect(res3.status).toBe(200);
+    const data3 = await res3.json();
+    expect(data3.balance.posted).toBe(300);
+
+    const res4 = await callCredit(auth, cookies, {
+      amount: 1,
+      idempotencyKey: "lifecycle-verify",
+    });
+    expect(res4.status).toBe(200);
+    const data4 = await res4.json();
+    expect(data4.balance.posted).toBe(301);
+  });
+});
+
+describe("integration: double-entry invariant", () => {
+  it("SUM(debits) === SUM(credits) after credit", async () => {
+    const { auth } = createTestAuth();
+    const adapter = getAdapter(auth);
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 150,
+      idempotencyKey: "double-entry-1",
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    const txId = data.transaction.id;
+    const entries = await adapter.findMany({
+      model: "walletEntry",
+      where: [{ field: "transactionId", value: txId }],
+    });
+
+    const debitSum = entries
+      .filter((e) => e.entryType === "DEBIT")
+      .reduce((sum, e) => sum + (e.amount as number), 0);
+    const creditSum = entries
+      .filter((e) => e.entryType === "CREDIT")
+      .reduce((sum, e) => sum + (e.amount as number), 0);
+
+    expect(debitSum).toBe(150);
+    expect(creditSum).toBe(150);
+    expect(debitSum).toBe(creditSum);
+  });
+});
+
+describe("integration: system accounts updated", () => {
+  it("sys_revenue postedBalance reflects total credits", async () => {
+    const { auth } = createTestAuth();
+    const adapter = getAdapter(auth);
+    const { cookies } = await signUpDirect(auth);
+
+    await callCredit(auth, cookies, {
+      amount: 500,
+      idempotencyKey: "sys-account-1",
+    });
+
+    const revenueAccount = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.REVENUE }],
+    });
+
+    expect(revenueAccount).toBeDefined();
+    expect(revenueAccount!.postedBalance).toBe(500);
+  });
+});
+
+describe("integration: multiple users isolated", () => {
+  it("credits to userA do not affect userB balance", async () => {
+    const { auth } = createTestAuth();
+
+    const userA = await signUpDirect(auth);
+    const userB = await signUpDirect(auth);
+
+    await callCredit(auth, userA.cookies, {
+      amount: 100,
+      idempotencyKey: "iso-userA-1",
+    });
+    const resA = await callCredit(auth, userA.cookies, {
+      amount: 100,
+      idempotencyKey: "iso-userA-1b",
+    });
+    expect(resA.status).toBe(200);
+
+    await callCredit(auth, userB.cookies, {
+      amount: 200,
+      idempotencyKey: "iso-userB-1",
+    });
+    const resB = await callCredit(auth, userB.cookies, {
+      amount: 200,
+      idempotencyKey: "iso-userB-1b",
+    });
+    expect(resB.status).toBe(200);
+
+    const resACheck = await callCredit(auth, userA.cookies, {
+      amount: 1,
+      idempotencyKey: "iso-userA-check",
+    });
+    const dataACheck = await resACheck.json();
+    expect(dataACheck.balance.posted).toBe(201);
+
+    const resBCheck = await callCredit(auth, userB.cookies, {
+      amount: 1,
+      idempotencyKey: "iso-userB-check",
+    });
+    const dataBCheck = await resBCheck.json();
+    expect(dataBCheck.balance.posted).toBe(401);
+  });
+});
+
+describe("integration: error scenarios", () => {
+  it("rejects credit with amount 0", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 0,
+      idempotencyKey: "err-zero",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects credit with negative amount", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: -10,
+      idempotencyKey: "err-neg",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects credit without authentication", async () => {
+    const { auth } = createTestAuth();
+
+    const res = await callCredit(auth, "", {
+      amount: 100,
+      idempotencyKey: "err-noauth",
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("returns original result on duplicate idempotency key", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    const res1 = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "err-dup-key",
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await callCredit(auth, cookies, {
+      amount: 200,
+      idempotencyKey: "err-dup-key",
+    });
+    expect(res2.status).toBe(200);
+    const data2 = await res2.json();
+    expect(data2.transaction.idempotencyKey).toBe("err-dup-key");
+    expect(data2.balance.posted).toBe(100);
+  });
+});
+
+describe("integration: onTopUp hook", () => {
+  it("calls onTopUp hook with correct context", async () => {
+    const onTopUp = vi.fn();
+    const { auth } = createTestAuth({
+      hooks: { onTopUp },
+    } satisfies TokenWalletOptions);
+    const { userId, cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "hook-intg-1",
+    });
+    expect(res.status).toBe(200);
+
+    expect(onTopUp).toHaveBeenCalledOnce();
+    const hookCtx = onTopUp.mock.calls[0]![0];
+
+    expect(hookCtx.transaction.transactionType).toBe("CREDIT_TOPUP");
+    expect(hookCtx.transaction.idempotencyKey).toBe("hook-intg-1");
+    expect(hookCtx.transaction.status).toBe("posted");
+    expect(hookCtx.entries).toHaveLength(2);
+    expect(hookCtx.user.id).toBe(userId);
+    expect(hookCtx.wallet).toBeDefined();
+    expect(hookCtx.wallet.postedBalance).toBeDefined();
+  });
+});
+
+describe("integration: balance invariant after multiple operations", () => {
+  it("available === posted (no pending debits in Phase 1)", async () => {
+    const { auth } = createTestAuth();
+    const { cookies } = await signUpDirect(auth);
+
+    await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "invariant-1",
+    });
+    await callCredit(auth, cookies, {
+      amount: 200,
+      idempotencyKey: "invariant-2",
+    });
+    const res3 = await callCredit(auth, cookies, {
+      amount: 50,
+      idempotencyKey: "invariant-3",
+    });
+
+    expect(res3.status).toBe(200);
+    const data = await res3.json();
+    expect(data.balance.posted).toBe(350);
+    expect(data.balance.available).toBe(350);
+    expect(data.balance.pending).toBe(0);
+    expect(data.balance.available).toBe(data.balance.posted);
+  });
+});
+
+describe("integration: schema customization", () => {
+  it("credit flow works with custom schema options", async () => {
+    const { auth } = createTestAuth({
+      schema: {
+        walletAccount: {
+          fields: { postedBalance: "posted_balance" },
+        },
+      },
+    } satisfies TokenWalletOptions);
+    const { cookies } = await signUpDirect(auth);
+
+    const res = await callCredit(auth, cookies, {
+      amount: 100,
+      idempotencyKey: "schema-custom-1",
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.balance.posted).toBe(100);
+    expect(data.balance.available).toBe(100);
+  });
+});

--- a/packages/token-wallet/src/__tests__/ledger.test.ts
+++ b/packages/token-wallet/src/__tests__/ledger.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import {
+  validateBalance,
+  createTransaction,
+} from "../ledger/index.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import { tokenWallet } from "../index.js";
+
+function createTestAdapter(): WalletAdapter {
+  const auth = betterAuth({
+    emailAndPassword: { enabled: true },
+    database: memoryAdapter({
+      user: [],
+      session: [],
+      account: [],
+      verification: [],
+      walletAccount: [],
+      walletTransaction: [],
+      walletEntry: [],
+      walletHold: [],
+    }),
+    plugins: [tokenWallet()],
+  });
+  const factory = auth.options.database;
+  return factory(auth.options) as WalletAdapter;
+}
+
+async function seedAccounts(adapter: WalletAdapter) {
+  await adapter.create({
+    model: "walletAccount",
+    data: {
+      id: "sys_revenue",
+      referenceKey: "system:REVENUE",
+      referenceType: "system",
+      accountType: "SYSTEM_REVENUE",
+      postedBalance: 0,
+      pendingDebits: 0,
+      availableBalance: 0,
+      lockVersion: 0,
+      currency: "token",
+    },
+    forceAllowId: true,
+  });
+  await adapter.create({
+    model: "walletAccount",
+    data: {
+      referenceKey: "user:test",
+      referenceType: "user",
+      accountType: "USER_WALLET",
+      postedBalance: 0,
+      pendingDebits: 0,
+      availableBalance: 0,
+      lockVersion: 0,
+      currency: "token",
+    },
+  });
+}
+
+describe("ledger: validateBalance", () => {
+  it("returns true for balanced DEBIT/CREDIT entries", () => {
+    const result = validateBalance([
+      { entryType: "DEBIT", amount: 100 },
+      { entryType: "CREDIT", amount: 100 },
+    ]);
+    expect(result).toBe(true);
+  });
+
+  it("returns false for unbalanced entries", () => {
+    const result = validateBalance([
+      { entryType: "DEBIT", amount: 100 },
+      { entryType: "CREDIT", amount: 50 },
+    ]);
+    expect(result).toBe(false);
+  });
+
+  it("returns true for empty entries (0 === 0)", () => {
+    expect(validateBalance([])).toBe(true);
+  });
+});
+
+describe("ledger: createTransaction", () => {
+  it("creates balanced CREDIT_TOPUP transaction", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    const result = await createTransaction(adapter, {
+      idempotencyKey: "topup-001",
+      transactionType: "CREDIT_TOPUP",
+      entries: [
+        { accountId: "sys_revenue", entryType: "DEBIT", amount: 100, balanceType: "posted" },
+        { accountId: "user:test", entryType: "CREDIT", amount: 100, balanceType: "posted" },
+      ],
+    });
+
+    expect(result.transaction).toBeDefined();
+    expect(result.transaction.idempotencyKey).toBe("topup-001");
+    expect(result.transaction.transactionType).toBe("CREDIT_TOPUP");
+    expect(result.transaction.status).toBe("posted");
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it("rejects unbalanced entries", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    await expect(
+      createTransaction(adapter, {
+        idempotencyKey: "bad-001",
+        transactionType: "CREDIT_TOPUP",
+        entries: [
+          { accountId: "sys_revenue", entryType: "DEBIT", amount: 100, balanceType: "posted" },
+          { accountId: "user:test", entryType: "CREDIT", amount: 50, balanceType: "posted" },
+        ],
+      }),
+    ).rejects.toThrow("CREDIT_FAILED");
+  });
+
+  it("creates entries atomically within transaction", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    const result = await createTransaction(adapter, {
+      idempotencyKey: "atomic-001",
+      transactionType: "CREDIT_TOPUP",
+      entries: [
+        { accountId: "sys_revenue", entryType: "DEBIT", amount: 200, balanceType: "posted" },
+        { accountId: "user:test", entryType: "CREDIT", amount: 200, balanceType: "posted" },
+      ],
+    });
+
+    expect(result.entries).toHaveLength(2);
+    const txId = result.transaction.id;
+    expect(result.entries[0].transactionId).toBe(txId);
+    expect(result.entries[1].transactionId).toBe(txId);
+  });
+
+  it("supports posted balance type", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    const result = await createTransaction(adapter, {
+      idempotencyKey: "posted-001",
+      transactionType: "CREDIT_TOPUP",
+      entries: [
+        { accountId: "sys_revenue", entryType: "DEBIT", amount: 50, balanceType: "posted" },
+        { accountId: "user:test", entryType: "CREDIT", amount: 50, balanceType: "posted" },
+      ],
+    });
+
+    expect(result.entries[0].balanceType).toBe("posted");
+    expect(result.entries[1].balanceType).toBe("posted");
+  });
+
+  it("links entries to transaction and account correctly", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    const result = await createTransaction(adapter, {
+      idempotencyKey: "link-001",
+      transactionType: "CREDIT_TOPUP",
+      entries: [
+        { accountId: "sys_revenue", entryType: "DEBIT", amount: 75, balanceType: "posted" },
+        { accountId: "user:test", entryType: "CREDIT", amount: 75, balanceType: "posted" },
+      ],
+    });
+
+    const [debit, credit] = result.entries;
+    expect(debit.accountId).toBe("sys_revenue");
+    expect(debit.entryType).toBe("DEBIT");
+    expect(debit.amount).toBe(75);
+    expect(debit.transactionId).toBe(result.transaction.id);
+
+    expect(credit.accountId).toBe("user:test");
+    expect(credit.entryType).toBe("CREDIT");
+    expect(credit.amount).toBe(75);
+    expect(credit.transactionId).toBe(result.transaction.id);
+  });
+
+  it("rejects negative, zero, and decimal amounts", async () => {
+    const adapter = createTestAdapter();
+    await seedAccounts(adapter);
+
+    const makeEntries = (amount: number) => [
+      { accountId: "sys_revenue", entryType: "DEBIT" as const, amount, balanceType: "posted" as const },
+      { accountId: "user:test", entryType: "CREDIT" as const, amount, balanceType: "posted" as const },
+    ];
+
+    await expect(
+      createTransaction(adapter, {
+        idempotencyKey: "neg-001",
+        transactionType: "CREDIT_TOPUP",
+        entries: makeEntries(-100),
+      }),
+    ).rejects.toThrow("INVALID_AMOUNT");
+
+    await expect(
+      createTransaction(adapter, {
+        idempotencyKey: "zero-001",
+        transactionType: "CREDIT_TOPUP",
+        entries: makeEntries(0),
+      }),
+    ).rejects.toThrow("INVALID_AMOUNT");
+
+    await expect(
+      createTransaction(adapter, {
+        idempotencyKey: "decimal-001",
+        transactionType: "CREDIT_TOPUP",
+        entries: makeEntries(1.5),
+      }),
+    ).rejects.toThrow("INVALID_AMOUNT");
+  });
+});

--- a/packages/token-wallet/src/__tests__/schema-customization.test.ts
+++ b/packages/token-wallet/src/__tests__/schema-customization.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { buildSchema, resolveTableName, resolveFieldName } from "../schema-resolver.js";
+import { tokenWallet } from "../index.js";
+
+describe("schema customization", () => {
+  it("default schema has expected table names", () => {
+    const schema = buildSchema();
+    const tables = Object.keys(schema);
+    expect(tables).toContain("walletAccount");
+    expect(tables).toContain("walletTransaction");
+    expect(tables).toContain("walletEntry");
+    expect(tables).toContain("walletHold");
+    expect(tables).toHaveLength(4);
+  });
+
+  it("default schema has expected field names", () => {
+    const schema = buildSchema();
+    const walletAccountFields = Object.keys(schema.walletAccount.fields);
+    expect(walletAccountFields).toContain("referenceKey");
+    expect(walletAccountFields).toContain("referenceType");
+    expect(walletAccountFields).toContain("accountType");
+    expect(walletAccountFields).toContain("postedBalance");
+    expect(walletAccountFields).toContain("pendingDebits");
+    expect(walletAccountFields).toContain("availableBalance");
+    expect(walletAccountFields).toContain("lockVersion");
+    expect(walletAccountFields).toContain("currency");
+    expect(walletAccountFields).toContain("createdAt");
+    expect(walletAccountFields).toContain("updatedAt");
+  });
+
+  it("custom table name override works via modelName", () => {
+    const schema = buildSchema({
+      walletAccount: { tableName: "my_wallets" },
+    });
+    expect(schema.walletAccount.modelName).toBe("my_wallets");
+  });
+
+  it("custom field name override works via fieldName", () => {
+    const schema = buildSchema({
+      walletAccount: {
+        fields: { postedBalance: "posted_bal" },
+      },
+    });
+    expect(schema.walletAccount.fields.postedBalance.fieldName).toBe(
+      "posted_bal",
+    );
+  });
+
+  it("multiple overrides work simultaneously", () => {
+    const schema = buildSchema({
+      walletAccount: {
+        tableName: "my_wallets",
+        fields: {
+          postedBalance: "posted_bal",
+          availableBalance: "avail_bal",
+        },
+      },
+      walletTransaction: {
+        tableName: "my_transactions",
+        fields: { idempotencyKey: "idem_key" },
+      },
+    });
+    expect(schema.walletAccount.modelName).toBe("my_wallets");
+    expect(schema.walletAccount.fields.postedBalance.fieldName).toBe(
+      "posted_bal",
+    );
+    expect(schema.walletAccount.fields.availableBalance.fieldName).toBe(
+      "avail_bal",
+    );
+    expect(schema.walletTransaction.modelName).toBe("my_transactions");
+    expect(schema.walletTransaction.fields.idempotencyKey.fieldName).toBe(
+      "idem_key",
+    );
+    expect(
+      (schema.walletAccount.fields.referenceKey as Record<string, unknown>)
+        .fieldName,
+    ).toBeUndefined();
+  });
+
+  it("unknown table/field names in overrides are ignored", () => {
+    const schema = buildSchema({
+      unknownTable: { tableName: "ignored" },
+      walletAccount: {
+        fields: { unknownField: "ignored_col" },
+      },
+    });
+    expect(Object.keys(schema)).not.toContain("unknownTable");
+
+    expect(
+      (schema.walletAccount.fields.referenceKey as Record<string, unknown>)
+        .fieldName,
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveTableName", () => {
+  it("returns default when no overrides", () => {
+    expect(resolveTableName(undefined, "walletAccount", "walletAccount")).toBe(
+      "walletAccount",
+    );
+  });
+
+  it("returns override when provided", () => {
+    const overrides = { walletAccount: { tableName: "my_wallets" } };
+    expect(resolveTableName(overrides, "walletAccount", "walletAccount")).toBe(
+      "my_wallets",
+    );
+  });
+});
+
+describe("resolveFieldName", () => {
+  it("returns default when no overrides", () => {
+    expect(
+      resolveFieldName(undefined, "walletAccount", "postedBalance", "postedBalance"),
+    ).toBe("postedBalance");
+  });
+
+  it("returns override when provided", () => {
+    const overrides = {
+      walletAccount: { fields: { postedBalance: "posted_bal" } },
+    };
+    expect(
+      resolveFieldName(
+        overrides,
+        "walletAccount",
+        "postedBalance",
+        "postedBalance",
+      ),
+    ).toBe("posted_bal");
+  });
+});
+
+describe("schema customization via plugin options", () => {
+  it("plugin passes schema overrides to schema builder", () => {
+    const plugin = tokenWallet({
+      schema: {
+        walletAccount: {
+          tableName: "custom_wallets",
+          fields: { postedBalance: "posted_balance" },
+        },
+      },
+    });
+    expect(plugin.schema).toBeDefined();
+    const schema = plugin.schema!;
+    expect((schema.walletAccount as Record<string, unknown>).modelName).toBe(
+      "custom_wallets",
+    );
+    const fields = schema.walletAccount.fields as unknown as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(fields.postedBalance.fieldName).toBe("posted_balance");
+  });
+});

--- a/packages/token-wallet/src/__tests__/smoke.test.ts
+++ b/packages/token-wallet/src/__tests__/smoke.test.ts
@@ -6,8 +6,8 @@ describe('token-wallet smoke test', () => {
     expect(typeof tokenWallet).toBe('function');
   });
 
-  it('tokenWallet returns { id: "token-wallet" }', () => {
+  it('tokenWallet returns plugin with id "token-wallet"', () => {
     const result = tokenWallet();
-    expect(result).toEqual({ id: 'token-wallet' });
+    expect(result.id).toBe('token-wallet');
   });
 });

--- a/packages/token-wallet/src/__tests__/spike-database-hooks.test.ts
+++ b/packages/token-wallet/src/__tests__/spike-database-hooks.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import type { BetterAuthPlugin } from "better-auth";
+import { betterAuth } from "better-auth";
+import { createAuthClient } from "better-auth/client";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { tokenWalletSchema } from "../schema.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+
+/**
+ * SPIKE: Validate that plugin init() can inject databaseHooks.user.create.after
+ * and that the hook fires when a user signs up. If this fails, we must
+ * use endpoint hooks instead for wallet auto-creation.
+ */
+describe("spike: databaseHooks injection", () => {
+  function createAuthWithPlugin(plugin: BetterAuthPlugin) {
+    const auth = betterAuth({
+      emailAndPassword: { enabled: true },
+      database: memoryAdapter({
+        user: [],
+        session: [],
+        account: [],
+        verification: [],
+        walletAccount: [],
+        walletTransaction: [],
+        walletEntry: [],
+        walletHold: [],
+      }),
+      plugins: [plugin],
+    });
+    const client = createAuthClient({
+      baseURL: "http://localhost:3000",
+      fetchOptions: {
+        customFetchImpl: async (url, init) => {
+          const req = new Request(url.toString(), init);
+          return auth.handler(req);
+        },
+      },
+    });
+    return { auth, client };
+  }
+
+  it("fires user.create.after hook on signup", async () => {
+    let hookFired = false;
+    let capturedUser: unknown = null;
+
+    const testPlugin: BetterAuthPlugin = {
+      id: "token-wallet",
+      schema: tokenWalletSchema,
+      init: () => ({
+        options: {
+          databaseHooks: {
+            user: {
+              create: {
+                after: async (user: unknown) => {
+                  hookFired = true;
+                  capturedUser = user;
+                },
+              },
+            },
+          },
+        },
+      }),
+      endpoints: {},
+      $Infer: { options: undefined },
+      $ERROR_CODES: TOKEN_WALLET_ERROR_CODES,
+    };
+
+    const { client } = createAuthWithPlugin(testPlugin);
+
+    const res = await client.signUp.email({
+      email: "hook-test@example.com",
+      password: "test1234",
+      name: "Hook Test User",
+    });
+
+    expect(res.error).toBeFalsy();
+    expect(res.data?.user).toBeDefined();
+
+    // databaseHooks.after is fire-and-forget (post-transaction) — wait briefly
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(hookFired).toBe(true);
+    expect(capturedUser).toBeDefined();
+  });
+
+  it("hook receives the created user object", async () => {
+    let capturedUser: Record<string, unknown> | null = null;
+
+    const testPlugin: BetterAuthPlugin = {
+      id: "token-wallet",
+      schema: tokenWalletSchema,
+      init: () => ({
+        options: {
+          databaseHooks: {
+            user: {
+              create: {
+                after: async (user: Record<string, unknown>) => {
+                  capturedUser = user;
+                },
+              },
+            },
+          },
+        },
+      }),
+      endpoints: {},
+      $Infer: { options: undefined },
+      $ERROR_CODES: TOKEN_WALLET_ERROR_CODES,
+    };
+
+    const { client } = createAuthWithPlugin(testPlugin);
+
+    const res = await client.signUp.email({
+      email: "user-verify@example.com",
+      password: "test1234",
+      name: "User Verify",
+    });
+
+    expect(res.error).toBeFalsy();
+
+    // databaseHooks.after is fire-and-forget (post-transaction) — wait briefly
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(capturedUser).not.toBeNull();
+    expect(capturedUser!.email).toBe("user-verify@example.com");
+    expect(capturedUser!.id).toBeDefined();
+    expect(typeof capturedUser!.id).toBe("string");
+  });
+
+  it("actual tokenWallet plugin does not crash on signup", async () => {
+    const { tokenWallet } = await import("../index.js");
+    const { client } = createAuthWithPlugin(tokenWallet());
+
+    const res = await client.signUp.email({
+      email: "real-plugin@example.com",
+      password: "test1234",
+      name: "Real Plugin Test",
+    });
+
+    expect(res.error).toBeFalsy();
+    expect(res.data?.user).toBeDefined();
+    expect(res.data?.user.email).toBe("real-plugin@example.com");
+  });
+});

--- a/packages/token-wallet/src/__tests__/system-accounts.test.ts
+++ b/packages/token-wallet/src/__tests__/system-accounts.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestAdapter } from "./helpers/test-setup.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import { seedSystemAccounts, SYSTEM_ACCOUNT_IDS } from "../system-accounts/index.js";
+
+describe("system-accounts module", () => {
+  let adapter: WalletAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  it("creates all three system accounts", async () => {
+    await seedSystemAccounts(adapter);
+
+    const revenue = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.REVENUE }],
+    });
+    const escrow = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.ESCROW }],
+    });
+    const reserve = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.RESERVE }],
+    });
+
+    expect(revenue).toBeDefined();
+    expect(escrow).toBeDefined();
+    expect(reserve).toBeDefined();
+  });
+
+  it("sets correct account types", async () => {
+    await seedSystemAccounts(adapter);
+
+    const revenue = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.REVENUE }],
+    });
+    const escrow = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.ESCROW }],
+    });
+    const reserve = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.RESERVE }],
+    });
+
+    expect(revenue?.accountType).toBe("SYSTEM_REVENUE");
+    expect(escrow?.accountType).toBe("SYSTEM_ESCROW");
+    expect(reserve?.accountType).toBe("SYSTEM_RESERVE");
+  });
+
+  it("initializes all balances to zero", async () => {
+    await seedSystemAccounts(adapter);
+
+    for (const id of Object.values(SYSTEM_ACCOUNT_IDS)) {
+      const account = await adapter.findOne({
+        model: "walletAccount",
+        where: [{ field: "id", value: id }],
+      });
+      expect(account?.postedBalance).toBe(0);
+      expect(account?.pendingDebits).toBe(0);
+      expect(account?.availableBalance).toBe(0);
+    }
+  });
+
+  it("is idempotent — seeding twice does not duplicate", async () => {
+    await seedSystemAccounts(adapter);
+    await seedSystemAccounts(adapter);
+
+    const all = await adapter.findMany({
+      model: "walletAccount",
+      where: [{ field: "referenceType", value: "system" }],
+    });
+
+    const uniqueIds = new Set(all.map((a) => a.id));
+    expect(uniqueIds.size).toBe(3);
+  });
+});

--- a/packages/token-wallet/src/__tests__/wallet-account.test.ts
+++ b/packages/token-wallet/src/__tests__/wallet-account.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestAdapter } from "./helpers/test-setup.js";
+import type { WalletAdapter } from "../ledger/index.js";
+import {
+  findWalletByReference,
+  getOrCreateUserWallet,
+  registerAutoCreateHook,
+} from "../wallet-account/index.js";
+
+describe("wallet-account module", () => {
+  let adapter: WalletAdapter;
+
+  beforeEach(() => {
+    adapter = createTestAdapter();
+  });
+
+  describe("findWalletByReference", () => {
+    it("returns null when wallet does not exist", async () => {
+      const wallet = await findWalletByReference(adapter, "user:test123");
+      expect(wallet).toBeNull();
+    });
+
+    it("returns wallet when wallet exists", async () => {
+      await getOrCreateUserWallet(adapter, "user:test123", 100);
+      const wallet = await findWalletByReference(adapter, "user:test123");
+      expect(wallet).toBeDefined();
+      expect(wallet?.referenceKey).toBe("user:test123");
+      expect(wallet?.accountType).toBe("USER_WALLET");
+    });
+  });
+
+  describe("getOrCreateUserWallet", () => {
+    it("creates USER_WALLET with zero initial balance", async () => {
+      const wallet = await getOrCreateUserWallet(adapter, "user:test123");
+
+      expect(wallet).toBeDefined();
+      expect(wallet?.referenceKey).toBe("user:test123");
+      expect(wallet?.referenceType).toBe("user");
+      expect(wallet?.accountType).toBe("USER_WALLET");
+      expect(wallet?.postedBalance).toBe(0);
+      expect(wallet?.pendingDebits).toBe(0);
+      expect(wallet?.availableBalance).toBe(0);
+      expect(wallet?.lockVersion).toBe(0);
+      expect(wallet?.currency).toBe("token");
+    });
+
+    it("creates USER_WALLET with custom initial balance", async () => {
+      const wallet = await getOrCreateUserWallet(
+        adapter,
+        "user:test123",
+        1000,
+      );
+
+      expect(wallet).toBeDefined();
+      expect(wallet?.postedBalance).toBe(1000);
+      expect(wallet?.availableBalance).toBe(1000);
+    });
+
+    it("find-or-create returns existing wallet", async () => {
+      const wallet1 = await getOrCreateUserWallet(adapter, "user:test123", 500);
+      const wallet2 = await getOrCreateUserWallet(adapter, "user:test123", 1000);
+
+      expect(wallet1).toEqual(wallet2);
+      expect(wallet1?.postedBalance).toBe(500);
+    });
+
+    it("find-or-create creates new wallet if absent", async () => {
+      const wallet1 = await getOrCreateUserWallet(adapter, "user:test123", 500);
+      const wallet2 = await getOrCreateUserWallet(adapter, "user:test456", 300);
+
+      expect(wallet1).toBeDefined();
+      expect(wallet2).toBeDefined();
+      expect(wallet1?.referenceKey).toBe("user:test123");
+      expect(wallet2?.referenceKey).toBe("user:test456");
+    });
+  });
+
+  describe("registerAutoCreateHook", () => {
+    it("creates wallet on signup when autoCreate is true", async () => {
+      const hook = registerAutoCreateHook(adapter, {
+        autoCreate: true,
+        initialBalance: 0,
+      });
+
+      await hook({ id: "user1" });
+
+      const wallet = await findWalletByReference(adapter, "user:user1");
+      expect(wallet).toBeDefined();
+      expect(wallet?.referenceKey).toBe("user:user1");
+    });
+
+    it("respects autoCreate: false", async () => {
+      const hook = registerAutoCreateHook(adapter, {
+        autoCreate: false,
+        initialBalance: 0,
+      });
+
+      await hook({ id: "user2" });
+
+      const wallet = await findWalletByReference(adapter, "user:user2");
+      expect(wallet).toBeNull();
+    });
+
+    it("passes initialBalance to created wallet", async () => {
+      const hook = registerAutoCreateHook(adapter, {
+        autoCreate: true,
+        initialBalance: 500,
+      });
+
+      await hook({ id: "user3" });
+
+      const wallet = await findWalletByReference(adapter, "user:user3");
+      expect(wallet?.postedBalance).toBe(500);
+      expect(wallet?.availableBalance).toBe(500);
+    });
+  });
+
+  describe("concurrency", () => {
+    it("unique referenceKey enforced", async () => {
+      await getOrCreateUserWallet(adapter, "user:test123", 100);
+      await getOrCreateUserWallet(adapter, "user:test123", 200);
+
+      const wallet = await findWalletByReference(adapter, "user:test123");
+      expect(wallet).toBeDefined();
+      expect(wallet?.postedBalance).toBe(100);
+    });
+  });
+});

--- a/packages/token-wallet/src/balance/index.ts
+++ b/packages/token-wallet/src/balance/index.ts
@@ -1,0 +1,58 @@
+import type { WalletAdapter } from "../ledger/index.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+import type { WalletBalance } from "../types.js";
+
+export function validateAmount(amount: number): void {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error(TOKEN_WALLET_ERROR_CODES.INVALID_AMOUNT.code);
+  }
+}
+
+export async function creditBalance(
+  adapter: WalletAdapter,
+  accountId: string,
+  amount: number,
+): Promise<void> {
+  validateAmount(amount);
+
+  const account = await adapter.findOne({
+    model: "walletAccount",
+    where: [{ field: "id", value: accountId }],
+  });
+
+  if (!account) {
+    throw new Error(TOKEN_WALLET_ERROR_CODES.WALLET_NOT_FOUND.code);
+  }
+
+  const currentPosted = (account.postedBalance as number) ?? 0;
+  const currentAvailable = (account.availableBalance as number) ?? 0;
+
+  await adapter.update({
+    model: "walletAccount",
+    update: {
+      postedBalance: currentPosted + amount,
+      availableBalance: currentAvailable + amount,
+    },
+    where: [{ field: "id", value: accountId }],
+  });
+}
+
+export async function getBalance(
+  adapter: WalletAdapter,
+  referenceKey: string,
+): Promise<WalletBalance> {
+  const account = await adapter.findOne({
+    model: "walletAccount",
+    where: [{ field: "referenceKey", value: referenceKey }],
+  });
+
+  if (!account) {
+    throw new Error(TOKEN_WALLET_ERROR_CODES.WALLET_NOT_FOUND.code);
+  }
+
+  return {
+    posted: (account.postedBalance as number) ?? 0,
+    pending: (account.pendingDebits as number) ?? 0,
+    available: (account.availableBalance as number) ?? 0,
+  };
+}

--- a/packages/token-wallet/src/client.ts
+++ b/packages/token-wallet/src/client.ts
@@ -1,3 +1,14 @@
-export const tokenWalletClient = () => {
-  return {} as const;
+import type { BetterAuthClientPlugin } from "better-auth/client";
+import type { tokenWallet } from "./index.js";
+import { TOKEN_WALLET_ERROR_CODES } from "./error-codes.js";
+
+export const tokenWalletClient = (): BetterAuthClientPlugin => {
+  return {
+    id: "token-wallet",
+    $InferServerPlugin: {} as ReturnType<typeof tokenWallet>,
+    pathMethods: {
+      "/token-wallet/credit": "POST" as const,
+    },
+    $ERROR_CODES: TOKEN_WALLET_ERROR_CODES,
+  };
 };

--- a/packages/token-wallet/src/endpoints/credit.ts
+++ b/packages/token-wallet/src/endpoints/credit.ts
@@ -1,0 +1,153 @@
+import {
+  createAuthEndpoint,
+  sessionMiddleware,
+  APIError,
+} from "better-auth/api";
+import * as z from "zod";
+import { createTransaction } from "../ledger/index.js";
+import { checkOrStore } from "../idempotency/index.js";
+import { creditBalance, getBalance } from "../balance/index.js";
+import { getOrCreateUserWallet } from "../wallet-account/index.js";
+import { SYSTEM_ACCOUNT_IDS, seedSystemAccounts } from "../system-accounts/index.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+import type { TokenWalletOptions, TopUpContext } from "../types.js";
+import type { WalletAdapter } from "../ledger/index.js";
+
+function getAdapter(ctx: {
+  context: Record<string, unknown>;
+}): WalletAdapter {
+  return ctx.context["adapter"] as unknown as WalletAdapter;
+}
+
+function rewriteError(error: Error): APIError | null {
+  const msg = error.message;
+  if (msg === TOKEN_WALLET_ERROR_CODES.INVALID_AMOUNT.code) {
+    return new APIError("BAD_REQUEST", {
+      ...TOKEN_WALLET_ERROR_CODES.INVALID_AMOUNT,
+    });
+  }
+  if (msg === TOKEN_WALLET_ERROR_CODES.MISSING_IDEMPOTENCY_KEY.code) {
+    return new APIError("BAD_REQUEST", {
+      ...TOKEN_WALLET_ERROR_CODES.MISSING_IDEMPOTENCY_KEY,
+    });
+  }
+  if (
+    msg === TOKEN_WALLET_ERROR_CODES.SYSTEM_ACCOUNT_MISSING.code ||
+    msg === TOKEN_WALLET_ERROR_CODES.CREDIT_FAILED.code
+  ) {
+    return new APIError("INTERNAL_SERVER_ERROR", {
+      code: msg,
+      message: TOKEN_WALLET_ERROR_CODES.CREDIT_FAILED.message,
+    });
+  }
+  return null;
+}
+
+export function createCreditEndpoint(
+  options?: TokenWalletOptions,
+): ReturnType<typeof createAuthEndpoint<any, any, any>> {
+  return createAuthEndpoint(
+    "/token-wallet/credit",
+    {
+      method: "POST",
+      body: z.object({
+        amount: z.number().int().positive(),
+        idempotencyKey: z.string().min(1),
+        metadata: z.record(z.unknown()).optional(),
+      }),
+      use: [sessionMiddleware],
+    },
+    async (ctx) => {
+      const session = ctx.context.session;
+      if (!session) {
+        throw new APIError("UNAUTHORIZED", { message: "Not authenticated" });
+      }
+
+      const user = session.user;
+      const adapter = getAdapter(ctx);
+      const referenceKey = `user:${user.id}`;
+      const { amount, idempotencyKey, metadata } = ctx.body;
+
+      try {
+        const result = await checkOrStore(
+          adapter,
+          idempotencyKey,
+          async () => {
+            await seedSystemAccounts(adapter);
+
+            const userWallet = await getOrCreateUserWallet(
+              adapter,
+              referenceKey,
+              options?.wallet?.initialBalance ?? 0,
+            );
+
+            const revenueAccount = await adapter.findOne({
+              model: "walletAccount",
+              where: [{ field: "id", value: SYSTEM_ACCOUNT_IDS.REVENUE }],
+            });
+
+            if (!revenueAccount) {
+              throw new Error(
+                TOKEN_WALLET_ERROR_CODES.SYSTEM_ACCOUNT_MISSING.code,
+              );
+            }
+
+            const txResult = await createTransaction(adapter, {
+              idempotencyKey,
+              transactionType: "CREDIT_TOPUP",
+              entries: [
+                {
+                  accountId: SYSTEM_ACCOUNT_IDS.REVENUE,
+                  entryType: "DEBIT" as const,
+                  amount,
+                  balanceType: "posted" as const,
+                },
+                {
+                  accountId: userWallet.id,
+                  entryType: "CREDIT" as const,
+                  amount,
+                  balanceType: "posted" as const,
+                },
+              ],
+              ...(metadata !== undefined ? { metadata } : {}),
+            });
+
+            await creditBalance(adapter, userWallet.id, amount);
+            await creditBalance(adapter, SYSTEM_ACCOUNT_IDS.REVENUE, amount);
+
+            if (options?.hooks?.onTopUp) {
+              await options.hooks.onTopUp({
+                transaction:
+                  txResult.transaction as unknown as TopUpContext["transaction"],
+                entries:
+                  txResult.entries as unknown as TopUpContext["entries"],
+                user: { id: user.id as string },
+                wallet: userWallet,
+              });
+            }
+
+            return {
+              transaction: txResult.transaction,
+              entries: txResult.entries,
+              userWallet,
+            };
+          },
+        );
+
+        const balance = await getBalance(adapter, referenceKey);
+
+        return ctx.json({
+          transaction: result.transaction,
+          entries: result.entries,
+          balance,
+        });
+      } catch (error) {
+        if (error instanceof Error) {
+          const apiError = rewriteError(error);
+          if (apiError) throw apiError;
+        }
+        throw error;
+      }
+    },
+  );
+}

--- a/packages/token-wallet/src/error-codes.ts
+++ b/packages/token-wallet/src/error-codes.ts
@@ -1,0 +1,10 @@
+export const TOKEN_WALLET_ERROR_CODES = {
+  WALLET_NOT_FOUND: { code: "WALLET_NOT_FOUND", message: "Wallet not found" },
+  INVALID_AMOUNT: { code: "INVALID_AMOUNT", message: "Invalid amount" },
+  DUPLICATE_IDEMPOTENCY_KEY: { code: "DUPLICATE_IDEMPOTENCY_KEY", message: "Duplicate idempotency key" },
+  SYSTEM_ACCOUNT_MISSING: { code: "SYSTEM_ACCOUNT_MISSING", message: "System account missing" },
+  MISSING_IDEMPOTENCY_KEY: { code: "MISSING_IDEMPOTENCY_KEY", message: "Missing idempotency key" },
+  CREDIT_FAILED: { code: "CREDIT_FAILED", message: "Credit failed" },
+} as const;
+
+export type TokenWalletErrorCode = keyof typeof TOKEN_WALLET_ERROR_CODES;

--- a/packages/token-wallet/src/idempotency/index.ts
+++ b/packages/token-wallet/src/idempotency/index.ts
@@ -1,0 +1,31 @@
+import type { WalletAdapter } from "../ledger/index.js";
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+
+export async function checkOrStore<T>(
+  adapter: WalletAdapter,
+  idempotencyKey: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!idempotencyKey || idempotencyKey.trim() === "") {
+    throw new Error(TOKEN_WALLET_ERROR_CODES.MISSING_IDEMPOTENCY_KEY.code);
+  }
+
+  const existing = await adapter.findOne({
+    model: "walletTransaction",
+    where: [{ field: "idempotencyKey", value: idempotencyKey }],
+  });
+
+  if (existing) {
+    const entries = await adapter.findMany({
+      model: "walletEntry",
+      where: [{ field: "transactionId", value: existing.id }],
+    });
+    return {
+      transaction: existing,
+      entries,
+      userWallet: null,
+    } as unknown as T;
+  }
+
+  return operation();
+}

--- a/packages/token-wallet/src/index.ts
+++ b/packages/token-wallet/src/index.ts
@@ -1,3 +1,87 @@
-export const tokenWallet = () => {
-  return { id: "token-wallet" } as const;
+import type { BetterAuthPlugin } from "better-auth";
+import { createCustomSchema } from "./schema.js";
+import { TOKEN_WALLET_ERROR_CODES } from "./error-codes.js";
+import type { TokenWalletOptions } from "./types.js";
+import { createCreditEndpoint } from "./endpoints/credit.js";
+import { registerAutoCreateHook } from "./wallet-account/index.js";
+import { seedSystemAccounts } from "./system-accounts/index.js";
+import type { WalletAdapter } from "./ledger/index.js";
+
+export const tokenWallet = (options?: TokenWalletOptions): BetterAuthPlugin => {
+  const schema = createCustomSchema(options?.schema);
+  return {
+    id: "token-wallet",
+    schema,
+    init: (ctx) => {
+      if (!ctx.options?.database) {
+        return {
+          options: {
+            databaseHooks: {
+              user: {
+                create: {
+                  after: async () => {},
+                },
+              },
+            },
+          },
+        };
+      }
+
+      const adapter = ctx.options.database(ctx.options) as unknown as WalletAdapter;
+
+      // Seed system accounts eagerly on init
+      seedSystemAccounts(adapter).catch(() => {});
+
+      const hookOpts: { autoCreate?: boolean; initialBalance?: number } = {};
+      if (options?.wallet?.autoCreate !== undefined) {
+        hookOpts.autoCreate = options.wallet.autoCreate;
+      }
+      if (options?.wallet?.initialBalance !== undefined) {
+        hookOpts.initialBalance = options.wallet.initialBalance;
+      }
+      const autoCreateFn = registerAutoCreateHook(adapter, hookOpts);
+
+      return {
+        options: {
+          databaseHooks: {
+            user: {
+              create: {
+                after: autoCreateFn,
+              },
+            },
+          },
+        },
+      };
+    },
+    endpoints: {
+      credit: createCreditEndpoint(options),
+    },
+    $Infer: {
+      options: options as TokenWalletOptions | undefined,
+    },
+    $ERROR_CODES: TOKEN_WALLET_ERROR_CODES,
+  };
 };
+
+export type {
+  TokenWalletOptions,
+  TopUpContext,
+  WalletAccount,
+  WalletTransaction,
+  WalletEntry,
+  WalletHold,
+  WalletBalance,
+  CreditRequest,
+  CreditResponse,
+  AccountType,
+  TransactionType,
+  EntryType,
+  BalanceType,
+} from "./types.js";
+export { TOKEN_WALLET_ERROR_CODES } from "./error-codes.js";
+
+declare module "better-auth" {
+  interface BetterAuthPluginRegistry<AuthOptions, Options> {
+    "token-wallet": ReturnType<typeof tokenWallet>;
+  }
+}

--- a/packages/token-wallet/src/ledger/index.ts
+++ b/packages/token-wallet/src/ledger/index.ts
@@ -1,0 +1,113 @@
+import { TOKEN_WALLET_ERROR_CODES } from "../error-codes.js";
+import type { EntryType, BalanceType } from "../types.js";
+
+export interface WalletAdapter {
+  findOne(args: {
+    model: string;
+    where: Array<{ field: string; value: unknown }>;
+  }): Promise<Record<string, unknown> | null>;
+
+  findMany(args: {
+    model: string;
+    where?: Array<{ field: string; value: unknown }>;
+  }): Promise<Record<string, unknown>[]>;
+
+  create(args: {
+    model: string;
+    data: Record<string, unknown>;
+    forceAllowId?: boolean;
+  }): Promise<Record<string, unknown>>;
+
+  update(args: {
+    model: string;
+    update: Record<string, unknown>;
+    where: Array<{ field: string; value: unknown }>;
+  }): Promise<Record<string, unknown>>;
+
+  transaction<T>(
+    callback: (tx: Omit<WalletAdapter, "transaction">) => Promise<T>,
+  ): Promise<T>;
+}
+
+export function validateBalance(
+  entries: Array<{ entryType: EntryType; amount: number }>,
+): boolean {
+  const debitSum = entries
+    .filter((e) => e.entryType === "DEBIT")
+    .reduce((sum, e) => sum + e.amount, 0);
+
+  const creditSum = entries
+    .filter((e) => e.entryType === "CREDIT")
+    .reduce((sum, e) => sum + e.amount, 0);
+
+  return debitSum === creditSum;
+}
+
+export async function createTransaction(
+  adapter: WalletAdapter,
+  params: {
+    idempotencyKey: string;
+    transactionType: string;
+    entries: Array<{
+      accountId: string;
+      entryType: EntryType;
+      amount: number;
+      balanceType: BalanceType;
+    }>;
+    metadata?: Record<string, unknown>;
+    referenceTxId?: string;
+  },
+): Promise<{
+  transaction: Record<string, unknown>;
+  entries: Record<string, unknown>[];
+}> {
+  if (params.entries.length === 0) {
+    throw new Error("Entries cannot be empty");
+  }
+
+  if (!validateBalance(params.entries)) {
+    throw new Error(TOKEN_WALLET_ERROR_CODES.CREDIT_FAILED.code);
+  }
+
+  for (const entry of params.entries) {
+    if (!Number.isInteger(entry.amount) || entry.amount <= 0) {
+      throw new Error(TOKEN_WALLET_ERROR_CODES.INVALID_AMOUNT.code);
+    }
+  }
+
+  return adapter.transaction(async (tx) => {
+    const transactionData: Record<string, unknown> = {
+      idempotencyKey: params.idempotencyKey,
+      transactionType: params.transactionType,
+      status: "posted",
+    };
+    if (params.metadata !== undefined) {
+      transactionData.metadata = params.metadata;
+    }
+    if (params.referenceTxId !== undefined) {
+      transactionData.referenceTxId = params.referenceTxId;
+    }
+
+    const transaction = await tx.create({
+      model: "walletTransaction",
+      data: transactionData,
+    });
+
+    const createdEntries: Record<string, unknown>[] = [];
+    for (const entry of params.entries) {
+      const created = await tx.create({
+        model: "walletEntry",
+        data: {
+          transactionId: transaction.id,
+          accountId: entry.accountId,
+          entryType: entry.entryType,
+          amount: entry.amount,
+          balanceType: entry.balanceType,
+        },
+      });
+      createdEntries.push(created);
+    }
+
+    return { transaction, entries: createdEntries };
+  });
+}

--- a/packages/token-wallet/src/schema-resolver.ts
+++ b/packages/token-wallet/src/schema-resolver.ts
@@ -1,0 +1,173 @@
+import type { BetterAuthPluginDBSchema, DBFieldAttribute } from "better-auth";
+
+export type SchemaOverrides = Record<
+  string,
+  { tableName?: string; fields?: Record<string, string> }
+>;
+
+export function resolveTableName(
+  overrides: SchemaOverrides | undefined,
+  modelName: string,
+  defaultName: string,
+): string {
+  return overrides?.[modelName]?.tableName ?? defaultName;
+}
+
+export function resolveFieldName(
+  overrides: SchemaOverrides | undefined,
+  modelName: string,
+  fieldName: string,
+  defaultFieldName: string,
+): string {
+  return overrides?.[modelName]?.fields?.[fieldName] ?? defaultFieldName;
+}
+
+function applyFieldOverrides(
+  fields: Record<string, DBFieldAttribute>,
+  modelOverrides: { fields?: Record<string, string> } | undefined,
+): Record<string, DBFieldAttribute> {
+  if (!modelOverrides?.fields) return fields;
+
+  const result: Record<string, DBFieldAttribute> = {};
+  for (const [name, fieldDef] of Object.entries(fields)) {
+    const override = modelOverrides.fields[name];
+    if (override !== undefined) {
+      result[name] = { ...fieldDef, fieldName: override };
+    } else {
+      result[name] = { ...fieldDef };
+    }
+  }
+  return result;
+}
+
+export function buildSchema(
+  overrides?: SchemaOverrides,
+): BetterAuthPluginDBSchema {
+  const baseSchema: BetterAuthPluginDBSchema = {
+    walletAccount: {
+      fields: {
+        referenceKey: { type: "string", required: true, unique: true },
+        referenceType: { type: "string", required: true },
+        accountType: { type: "string", required: true },
+        postedBalance: {
+          type: "number",
+          required: true,
+          defaultValue: 0,
+        },
+        pendingDebits: {
+          type: "number",
+          required: true,
+          defaultValue: 0,
+        },
+        availableBalance: {
+          type: "number",
+          required: true,
+          defaultValue: 0,
+        },
+        lockVersion: { type: "number", required: true, defaultValue: 0 },
+        currency: {
+          type: "string",
+          required: true,
+          defaultValue: "token",
+        },
+        createdAt: {
+          type: "date",
+          required: true,
+          defaultValue: (): Date => new Date(),
+        },
+        updatedAt: {
+          type: "date",
+          required: true,
+          defaultValue: (): Date => new Date(),
+        },
+      },
+    },
+    walletTransaction: {
+      fields: {
+        idempotencyKey: { type: "string", required: true, unique: true },
+        transactionType: { type: "string", required: true },
+        status: {
+          type: "string",
+          required: true,
+          defaultValue: "posted",
+        },
+        metadata: { type: "json", required: false },
+        referenceTxId: { type: "string", required: false },
+        createdAt: {
+          type: "date",
+          required: true,
+          defaultValue: (): Date => new Date(),
+        },
+      },
+    },
+    walletEntry: {
+      fields: {
+        transactionId: {
+          type: "string",
+          required: true,
+          references: { model: "walletTransaction", field: "id" },
+        },
+        accountId: {
+          type: "string",
+          required: true,
+          references: { model: "walletAccount", field: "id" },
+        },
+        entryType: { type: "string", required: true },
+        amount: { type: "number", required: true },
+        balanceType: { type: "string", required: true },
+        createdAt: {
+          type: "date",
+          required: true,
+          defaultValue: (): Date => new Date(),
+        },
+      },
+    },
+    walletHold: {
+      fields: {
+        transactionId: {
+          type: "string",
+          required: true,
+          references: { model: "walletTransaction", field: "id" },
+        },
+        accountId: {
+          type: "string",
+          required: true,
+          references: { model: "walletAccount", field: "id" },
+        },
+        status: {
+          type: "string",
+          required: true,
+          defaultValue: "active",
+        },
+        amount: { type: "number", required: true },
+        capturedAmount: { type: "number", required: false },
+        captureTransactionId: { type: "string", required: false },
+        voidTransactionId: { type: "string", required: false },
+        createdAt: {
+          type: "date",
+          required: true,
+          defaultValue: (): Date => new Date(),
+        },
+      },
+    },
+  };
+
+  if (!overrides) return baseSchema;
+
+  const result: BetterAuthPluginDBSchema = {};
+
+  for (const [modelName, modelDef] of Object.entries(baseSchema)) {
+    const modelOverrides = overrides[modelName];
+    const resolvedModel: (typeof baseSchema)[string] = {
+      fields: applyFieldOverrides(modelDef.fields, modelOverrides),
+    };
+
+    if (modelOverrides?.tableName) {
+      resolvedModel.modelName = modelOverrides.tableName;
+    }
+
+    result[modelName] = resolvedModel;
+  }
+
+  return result;
+}

--- a/packages/token-wallet/src/schema.ts
+++ b/packages/token-wallet/src/schema.ts
@@ -1,0 +1,11 @@
+import type { BetterAuthPluginDBSchema } from "better-auth";
+import { buildSchema } from "./schema-resolver.js";
+import type { SchemaOverrides } from "./schema-resolver.js";
+
+export const tokenWalletSchema: BetterAuthPluginDBSchema = buildSchema();
+
+export function createCustomSchema(
+  overrides?: SchemaOverrides,
+): BetterAuthPluginDBSchema {
+  return buildSchema(overrides);
+}

--- a/packages/token-wallet/src/system-accounts/index.ts
+++ b/packages/token-wallet/src/system-accounts/index.ts
@@ -1,0 +1,61 @@
+import type { WalletAdapter } from "../ledger/index.js";
+
+export const SYSTEM_ACCOUNT_IDS = {
+  REVENUE: "sys_revenue",
+  ESCROW: "sys_escrow",
+  RESERVE: "sys_reserve",
+} as const;
+
+export type SystemAccountId =
+  (typeof SYSTEM_ACCOUNT_IDS)[keyof typeof SYSTEM_ACCOUNT_IDS];
+
+const SYSTEM_ACCOUNT_CONFIGS: Array<{
+  id: string;
+  type: string;
+  referenceKey: string;
+}> = [
+  {
+    id: SYSTEM_ACCOUNT_IDS.REVENUE,
+    type: "REVENUE",
+    referenceKey: "system:REVENUE",
+  },
+  {
+    id: SYSTEM_ACCOUNT_IDS.ESCROW,
+    type: "ESCROW",
+    referenceKey: "system:ESCROW",
+  },
+  {
+    id: SYSTEM_ACCOUNT_IDS.RESERVE,
+    type: "RESERVE",
+    referenceKey: "system:RESERVE",
+  },
+];
+
+export async function seedSystemAccounts(
+  adapter: WalletAdapter,
+): Promise<void> {
+  for (const config of SYSTEM_ACCOUNT_CONFIGS) {
+    const existing = await adapter.findOne({
+      model: "walletAccount",
+      where: [{ field: "id", value: config.id }],
+    });
+
+    if (existing) continue;
+
+    await adapter.create({
+      model: "walletAccount",
+      data: {
+        id: config.id,
+        referenceKey: config.referenceKey,
+        referenceType: "system",
+        accountType: `SYSTEM_${config.type}`,
+        postedBalance: 0,
+        pendingDebits: 0,
+        availableBalance: 0,
+        lockVersion: 0,
+        currency: "token",
+      },
+      forceAllowId: true,
+    });
+  }
+}

--- a/packages/token-wallet/src/types.ts
+++ b/packages/token-wallet/src/types.ts
@@ -1,1 +1,86 @@
-export type {};
+export interface TokenWalletOptions {
+  wallet?: {
+    autoCreate?: boolean;
+    initialBalance?: number;
+  };
+  schema?: Record<string, { tableName?: string; fields?: Record<string, string> }>;
+  hooks?: {
+    onTopUp?: (ctx: TopUpContext) => Promise<void> | void;
+  };
+}
+
+export interface TopUpContext {
+  transaction: WalletTransaction;
+  entries: WalletEntry[];
+  user: { id: string };
+  wallet: WalletAccount;
+}
+
+export interface WalletAccount {
+  id: string;
+  referenceKey: string;
+  referenceType: string;
+  accountType: string;
+  postedBalance: number;
+  pendingDebits: number;
+  availableBalance: number;
+  lockVersion: number;
+  currency: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface WalletTransaction {
+  id: string;
+  idempotencyKey: string;
+  transactionType: string;
+  status: string;
+  metadata?: Record<string, unknown>;
+  referenceTxId?: string;
+  createdAt: Date;
+}
+
+export interface WalletEntry {
+  id: string;
+  transactionId: string;
+  accountId: string;
+  entryType: "DEBIT" | "CREDIT";
+  amount: number;
+  balanceType: "posted" | "pending";
+  createdAt: Date;
+}
+
+export interface WalletHold {
+  id: string;
+  transactionId: string;
+  accountId: string;
+  status: "active" | "captured" | "voided" | "expired";
+  amount: number;
+  capturedAmount?: number;
+  captureTransactionId?: string;
+  voidTransactionId?: string;
+  createdAt: Date;
+}
+
+export interface WalletBalance {
+  posted: number;
+  pending: number;
+  available: number;
+}
+
+export type AccountType = "USER_WALLET" | "SYSTEM_REVENUE" | "SYSTEM_ESCROW" | "SYSTEM_RESERVE";
+export type TransactionType = "CREDIT_TOPUP" | "API_DEBIT" | "HOLD" | "CAPTURE" | "VOID" | "REFUND" | "ADJUSTMENT";
+export type EntryType = "DEBIT" | "CREDIT";
+export type BalanceType = "posted" | "pending";
+
+export interface CreditRequest {
+  amount: number;
+  idempotencyKey: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreditResponse {
+  transaction: WalletTransaction;
+  entries: WalletEntry[];
+  balance: WalletBalance;
+}

--- a/packages/token-wallet/src/wallet-account/index.ts
+++ b/packages/token-wallet/src/wallet-account/index.ts
@@ -1,0 +1,78 @@
+import { WalletAdapter } from "../ledger/index.js";
+import type { WalletAccount } from "../types.js";
+
+/**
+ * Find an existing wallet by referenceKey
+ */
+export async function findWalletByReference(
+  adapter: WalletAdapter,
+  referenceKey: string,
+): Promise<WalletAccount | null> {
+  const wallet = await adapter.findOne({
+    model: "walletAccount",
+    where: [{ field: "referenceKey", value: referenceKey }],
+  });
+  return wallet as WalletAccount | null;
+}
+
+/**
+ * Find-or-create a user wallet
+ */
+export async function getOrCreateUserWallet(
+  adapter: WalletAdapter,
+  referenceKey: string,
+  initialBalance?: number,
+): Promise<WalletAccount> {
+  let wallet = await findWalletByReference(adapter, referenceKey);
+  if (wallet) return wallet;
+
+  const walletData = {
+    referenceKey,
+    referenceType: "user",
+    accountType: "USER_WALLET",
+    postedBalance: initialBalance ?? 0,
+    pendingDebits: 0,
+    availableBalance: initialBalance ?? 0,
+    lockVersion: 0,
+    currency: "token",
+  };
+
+  try {
+    wallet = (await adapter.create({
+      model: "walletAccount",
+      data: walletData,
+    })) as unknown as WalletAccount;
+    return wallet;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (String(error.message).includes("duplicate") ||
+        String(error.message).includes("constraint"))
+    ) {
+      wallet = await findWalletByReference(adapter, referenceKey);
+      if (wallet) return wallet;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Register the auto-create hook for databaseHooks.user.create.after
+ *
+ * This hook automatically creates a user wallet when a new user is created.
+ */
+export function registerAutoCreateHook(
+  adapter: WalletAdapter,
+  options?: {
+    autoCreate?: boolean;
+    initialBalance?: number;
+  },
+): (user: { id: string }) => Promise<void> {
+  const { autoCreate = true, initialBalance } = options ?? {};
+
+  return async (user: { id: string }) => {
+    if (!autoCreate) return;
+    const referenceKey = `user:${user.id}`;
+    await getOrCreateUserWallet(adapter, referenceKey, initialBalance);
+  };
+}

--- a/packages/token-wallet/tsconfig.json
+++ b/packages/token-wallet/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["./src"],
+  "exclude": ["./src/__tests__"],
   "compilerOptions": {
     "composite": true
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,10 +121,16 @@ importers:
 
   packages/token-wallet:
     dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.6(@opentelemetry/api@1.9.1)(next@16.2.1(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(lightningcss@1.32.0))
-    devDependencies:
+        version: 1.5.6(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(next@16.2.1(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(lightningcss@1.32.0))
+      better-sqlite3:
+        specifier: ^12.0.0
+        version: 12.8.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2137,6 +2143,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.12:
     resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
     engines: {node: '>=6.0.0'}
@@ -2216,9 +2225,19 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2232,6 +2251,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2281,6 +2303,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -2332,9 +2357,17 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -2369,6 +2402,9 @@ packages:
 
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -2438,6 +2474,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2464,6 +2504,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2488,6 +2531,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -2648,6 +2694,9 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -2711,6 +2760,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2719,6 +2771,12 @@ packages:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -3069,9 +3127,19 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
@@ -3115,6 +3183,9 @@ packages:
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -3168,6 +3239,10 @@ packages:
       sass:
         optional: true
 
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -3189,6 +3264,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
@@ -3361,6 +3439,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -3369,11 +3453,18 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -3426,6 +3517,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -3506,6 +3601,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -3546,6 +3644,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -3580,6 +3684,9 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -3590,6 +3697,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -3635,6 +3746,13 @@ packages:
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   term-size@2.2.1:
@@ -3700,6 +3818,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3857,6 +3978,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -3868,6 +3992,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3881,7 +4008,7 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
@@ -3894,36 +4021,36 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
+  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
       kysely: 0.28.14
 
-  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -5420,17 +5547,19 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.12: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(next@16.2.1(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(lightningcss@1.32.0)):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(next@16.2.1(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(lightningcss@1.32.0)):
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
-      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
+      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
@@ -5442,6 +5571,7 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
+      better-sqlite3: 12.8.0
       next: 16.2.1(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -5463,7 +5593,22 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@12.8.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -5480,6 +5625,11 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -5527,6 +5677,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@1.1.4: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -5563,7 +5715,13 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   defu@6.1.4: {}
 
@@ -5588,6 +5746,10 @@ snapshots:
   dlv@1.1.3: {}
 
   electron-to-chromium@1.5.328: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -5715,6 +5877,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -5737,6 +5901,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5756,6 +5922,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -5904,6 +6072,8 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  github-from-package@0.0.0: {}
+
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
@@ -6049,9 +6219,15 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   image-size@2.0.2: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -6624,9 +6800,15 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   motion-dom@12.38.0:
     dependencies:
@@ -6657,6 +6839,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.2.0: {}
+
+  napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
 
@@ -6714,6 +6898,10 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
@@ -6725,6 +6913,10 @@ snapshots:
   object-hash@3.0.0: {}
 
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.1: {}
 
@@ -6908,13 +7100,40 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   property-information@7.1.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -6965,6 +7184,12 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -7122,6 +7347,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
@@ -7187,6 +7414,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -7214,6 +7449,10 @@ snapshots:
 
   std-env@4.0.0: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -7224,6 +7463,8 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -7288,6 +7529,21 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   term-size@2.2.1: {}
 
   thenify-all@1.6.0:
@@ -7335,6 +7591,10 @@ snapshots:
       code-block-writer: 13.0.3
 
   tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   typescript@5.9.3: {}
 
@@ -7548,7 +7808,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary

- Implement the complete Phase 1 vertical slice of the Better Auth Token Wallet plugin
- Double-entry ledger engine with plugin factory, 4 DB tables, system account seeding, wallet auto-creation on signup, credit endpoint with idempotency, schema customization, and typed client plugin

## What's Included

- **Plugin factory** (`tokenWallet()`) with init seeding and auto-create hook
- **4 database tables**: walletAccount, walletTransaction, walletEntry, walletHold
- **System account manager** — idempotent seeding of REVENUE/ESCROW/RESERVE accounts
- **Wallet account manager** — find-or-create, auto-create on user signup via `databaseHooks.user.create.after`
- **Ledger engine** — `WalletAdapter` interface, double-entry validation (`SUM(debits) === SUM(credits)`), atomic transactions
- **Balance manager** — integer-only validation, credit operations
- **Idempotency guard** — returns existing result on duplicate key (true financial idempotency)
- **`POST /token-wallet/credit`** — Zod validation, session auth, full credit flow orchestration
- **Schema customization** — table/field name overrides via options
- **Client plugin** — full type inference via `$InferServerPlugin` + declaration merging
- **90 tests** across 12 test files (1.6:1 test-to-source ratio), 0 TypeScript errors

## By the Numbers

| Metric | Value |
|---|---|
| Source | ~965 lines across 12 modules |
| Tests | ~1,559 lines, 90 tests, 0 failures |
| `as any` / `@ts-ignore` | 0 |
| `parseFloat` / `Number()` on amounts | 0 |

Closes #9
Closes #2